### PR TITLE
Improve user experience and add RVC instruction

### DIFF
--- a/wasm-riscv-online/www/index.html
+++ b/wasm-riscv-online/www/index.html
@@ -135,8 +135,8 @@
     </style>
 </head>
 <body>
-    <h1>RISCV-ONLINE</h1>
-    <textarea id="input" placeholder="请输入汇编指令或十六进制机器码"></textarea>
+    <h1>RISC-V Online Disassembler</h1>
+    <textarea id="input" placeholder="请输入十六进制机器码"></textarea>
     <button id="convertButton">
         <i class="fas fa-sync-alt"></i> 转换/反汇编
     </button>

--- a/wasm-riscv-online/www/index.js
+++ b/wasm-riscv-online/www/index.js
@@ -8,18 +8,47 @@ try {
   const outputDisplay = document.getElementById('outputDisplay'); // 右侧框，显示结果的值
   // 为按钮添加点击事件监听器
   convertButton.addEventListener('click', () => {
-    const inputValue = input.value;
-    let wasmResult;
-    // 显示正在处理的图标
-    convertButton.classList.add('loading');
-    inputDisplay.textContent = `Input: ${inputValue}`;
+      const inputValue = input.value;
+      let hexValue = inputValue;
+  
+      // 检查并补齐输入的十六进制数
+      if (hexValue.startsWith("0x") || hexValue.startsWith("0X")) {
+          hexValue = hexValue.slice(2);
+      }
+    
+      // 如果输入值不是偶数位，前面补0
+      if (hexValue.length % 2 !== 0) {
+          hexValue = '0' + hexValue;
+      }
+    
+      // 转换为二进制字符串
+      const binaryStr = parseInt(hexValue, 16).toString(2).padStart(32, '0');
+    
+      // 判断指令位长
+      let formattedHexValue;
+      if (binaryStr.endsWith('11')) {
+          // 32位指令，确保长度为8个字符
+          hexValue = hexValue.padStart(8, '0');
+          formattedHexValue = '0x' + hexValue;
+      } else {
+          // 16位指令，确保长度为4个字符
+          hexValue = hexValue.padStart(4, '0');
+          formattedHexValue = '0x' + hexValue;
+      }
+    
+      let wasmResult;
+      // 显示正在处理的图标
+      convertButton.classList.add('loading');
+      inputDisplay.textContent = `Input: ${formattedHexValue}`;
+    
       // 调用 wasm 模块的 disassemble 函数进行反汇编
-      wasmResult = wasm.disassemble(inputValue);
+      wasmResult = wasm.disassemble(formattedHexValue);
       outputDisplay.textContent = `Disassembly: ${wasmResult}`;
-    // 处理完成后移除正在处理的图标
-    setTimeout(() => {
-      convertButton.classList.remove('loading');
-    }, 1000); // 假设处理过程需要1秒
+    
+      // 处理完成后移除正在处理的图标
+      setTimeout(() => {
+          convertButton.classList.remove('loading');
+      }, 1000); // 假设处理过程需要1秒
   });
 } catch (error) {
   // 如果初始化过程中出现错误，将错误信息记录到控制台


### PR DESCRIPTION
This PR mainly made the following changes：
**Input Display Issue**: The "Input" field did not indicate that the instructions are in hexadecimal format and did not specify the bit length, which could lead to confusion. The code will be modified to ensure that the bit length of the instruction in the "Input" field matches the output, with leading zeros added as necessary. For example, if a user inputs "12345678", the "Input" should display "0x12345678". If "123" is input, it should be displayed as "0x00000123".

**Register Naming**: The disassembled instructions did not display the names of the RISC-V integer registers. The code will be updated to show register names according to the RISC-V Assembly Programmer's Manual, using the "ABI name" such as "ra", "sp", and "gp". For instance, the instruction "sb 0, 2(0)" should be displayed as "sb zero, 2(zero)".

**User Guidance**: Users were unsure of how to use the web page after viewing it. The title will be changed from "RISCV-ONLINE" to "RISC-V Online Disassembler" for clarity.

**New Functionality - Compressed Instruction Set**: Support for one of the compressed C instructions from the RISC-V instruction set will be added. All C instructions are 16-bit long, so only up to 16 bits need to be entered in the "Input" field, such as "0x0012".