### PR TITLE
fix(rv32i): correct shamt field extraction for shift instructions

### DIFF
--- a/wasm-riscv-online/src/asm/rv32i.rs
+++ b/wasm-riscv-online/src/asm/rv32i.rs
@@ -246,24 +246,24 @@ impl RV32I {
                 to_register(i.rs1),
                 i.imm
             ),
-            Self::Slli(i) => format!(
-                "slli {}, {}, {:?}",
-                to_register(i.rd),
-                to_register(i.rs1),
-                i.imm
-            ), // TODO shamt，这里先用imm代替
-            Self::Srli(i) => format!(
-                "srli {}, {}, {:?}",
-                to_register(i.rd),
-                to_register(i.rs1),
-                i.imm
-            ), // TODO shamt，这里先用imm代替
-            Self::Srai(i) => format!(
-                "srai {}, {}, {:?}",
-                to_register(i.rd),
-                to_register(i.rs1),
-                i.imm
-            ), // TODO shamt，这里先用imm代替
+            Self::Slli(i) => format!(  
+                "slli {}, {}, {}",  
+                to_register(i.rd),  
+                to_register(i.rs1),  
+                i.imm.low_u32() & 0x1f  
+            ),  
+            Self::Srli(i) => format!(  
+                "srli {}, {}, {}",  
+                to_register(i.rd),  
+                to_register(i.rs1),  
+                i.imm.low_u32() & 0x1f  
+            ),  
+            Self::Srai(i) => format!(  
+                "srai {}, {}, {}",  
+                to_register(i.rd),  
+                to_register(i.rs1),  
+                i.imm.low_u32() & 0x1f 
+            ),
 
             Self::Fence(_) => format!("fence"),
             Self::Ecall(_) => format!("ecall"),


### PR DESCRIPTION
- Fix SLLI, SRLI, SRAI instructions to use proper 5-bit shamt field  
- Use imm.low_u32() & 0x1f instead of direct field access  
- Ensures compliance with RISC-V specification for shift amount display  
  
Resolves TODO comments and compilation errors in rv32i.rs  