### PR TITLE
feat: implement RVZicsr instruction formatting

### DIFF
--- a/wasm-riscv-online/src/asm/rvzicsr.rs
+++ b/wasm-riscv-online/src/asm/rvzicsr.rs
@@ -12,7 +12,7 @@ pub enum RVZicsr {
 
 impl RVZicsr {
     pub fn to_string(&self) -> String {
-        match self {  
+        match self {
             Self::Csrrw(csr) => format!(  
                 "csrrw {}, {:#x}, {}",  
                 to_register(csr.rd),  

--- a/wasm-riscv-online/src/asm/rvzicsr.rs
+++ b/wasm-riscv-online/src/asm/rvzicsr.rs
@@ -1,4 +1,4 @@
-use super::{CsrIType, CsrRType};
+use super::{to_register, CsrIType, CsrRType}; 
 
 #[derive(Debug, Clone, Copy)]
 pub enum RVZicsr {
@@ -12,7 +12,43 @@ pub enum RVZicsr {
 
 impl RVZicsr {
     pub fn to_string(&self) -> String {
-        // TODO
-        format!("RVZicsr Instruction")
+        match self {  
+            Self::Csrrw(csr) => format!(  
+                "csrrw {}, {:#x}, {}",  
+                to_register(csr.rd),  
+                csr.csr,  
+                to_register(csr.rs1)  
+            ),  
+            Self::Csrrs(csr) => format!(  
+                "csrrs {}, {:#x}, {}",  
+                to_register(csr.rd),  
+                csr.csr,  
+                to_register(csr.rs1)  
+            ),  
+            Self::Csrrc(csr) => format!(  
+                "csrrc {}, {:#x}, {}",  
+                to_register(csr.rd),  
+                csr.csr,  
+                to_register(csr.rs1)  
+            ),  
+            Self::Csrrwi(csr) => format!(  
+                "csrrwi {}, {:#x}, {:?}",  
+                to_register(csr.rd),  
+                csr.csr,  
+                csr.uimm  
+            ),  
+            Self::Csrrsi(csr) => format!(  
+                "csrrsi {}, {:#x}, {:?}",  
+                to_register(csr.rd),  
+                csr.csr,  
+                csr.uimm  
+            ),  
+            Self::Csrrci(csr) => format!(  
+                "csrrci {}, {:#x}, {:?}",  
+                to_register(csr.rd),  
+                csr.csr,  
+                csr.uimm  
+            ),  
+        }  
     }
 }

--- a/wasm-riscv-online/src/asm/rvzicsr.rs
+++ b/wasm-riscv-online/src/asm/rvzicsr.rs
@@ -1,4 +1,4 @@
-use super::{to_register, CsrIType, CsrRType}; 
+use super::{to_register, CsrIType, CsrRType};
 
 #[derive(Debug, Clone, Copy)]
 pub enum RVZicsr {

--- a/wasm-riscv-online/src/asm/rvzicsr.rs
+++ b/wasm-riscv-online/src/asm/rvzicsr.rs
@@ -49,6 +49,6 @@ impl RVZicsr {
                 csr.csr,  
                 csr.uimm  
             ),  
-        }  
+        }
     }
 }

--- a/wasm-riscv-online/src/asm/rvzicsr.rs
+++ b/wasm-riscv-online/src/asm/rvzicsr.rs
@@ -32,19 +32,19 @@ impl RVZicsr {
                 to_register(csr.rs1)  
             ),  
             Self::Csrrwi(csr) => format!(  
-                "csrrwi {}, {:#x}, {:?}",  
+                "csrrwi {}, {:#x}, {}",  
                 to_register(csr.rd),  
                 csr.csr,  
                 csr.uimm  
             ),  
             Self::Csrrsi(csr) => format!(  
-                "csrrsi {}, {:#x}, {:?}",  
+                "csrrsi {}, {:#x}, {}",  
                 to_register(csr.rd),  
                 csr.csr,  
                 csr.uimm  
             ),  
             Self::Csrrci(csr) => format!(  
-                "csrrci {}, {:#x}, {:?}",  
+                "csrrci {}, {:#x}, {}",  
                 to_register(csr.rd),  
                 csr.csr,  
                 csr.uimm  


### PR DESCRIPTION
- Add complete to_string() implementation for CSR instructions  
- Support CSRRW, CSRRS, CSRRC register-based operations    
- Support CSRRWI, CSRRSI, CSRRCI immediate-based operations  
- Use hexadecimal format for CSR addresses (e.g., 0x302)  
- Reuse existing to_register() function for register names  
- Follow project code style and formatting conventions