### PR TITLE
feat: add FENCE.I instruction support

### DIFF
--- a/wasm-riscv-online/src/asm/rv32i.rs
+++ b/wasm-riscv-online/src/asm/rv32i.rs
@@ -44,9 +44,21 @@ pub enum RV32I {
     Or(RType),
     And(RType),
 
-    Fence(IType),
-    Ecall(IType),
-    Ebreak(IType),
+    // Multiplication and Division instructions
+    Mul(RType),
+    Mulh(RType),
+    Mulhsu(RType),
+    Mulhu(RType),
+    Div(RType),
+    Divu(RType),
+    Rem(RType),
+    Remu(RType),
+
+    // System instructions with unit type
+    Fence(()),
+    FenceI(()),
+    Ecall(()),
+    Ebreak(()),
 }
 
 impl RV32I {
@@ -265,7 +277,56 @@ impl RV32I {
                 i.imm.low_u32() & 0x1f 
             ),
 
+            Self::Mul(r) => format!(
+                "mul {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Mulh(r) => format!(
+                "mulh {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Mulhsu(r) => format!(
+                "mulhsu {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Mulhu(r) => format!(
+                "mulhu {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Div(r) => format!(
+                "div {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Divu(r) => format!(
+                "divu {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Rem(r) => format!(
+                "rem {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
+            Self::Remu(r) => format!(
+                "remu {}, {}, {}",
+                to_register(r.rd),
+                to_register(r.rs1),
+                to_register(r.rs2)
+            ),
             Self::Fence(_) => format!("fence"),
+            Self::FenceI(_) => format!("fence.i"),
             Self::Ecall(_) => format!("ecall"),
             Self::Ebreak(_) => format!("ebreak"),
         }

--- a/wasm-riscv-online/src/decode/process32.rs
+++ b/wasm-riscv-online/src/decode/process32.rs
@@ -68,6 +68,7 @@ const FUNCT12_SYSTEM_ECALL: u32 = 0b000;
 const FUNCT12_SYSTEM_EBREAK: u32 = 0b001;
 
 const FUNCT3_MISC_MEM_FENCE: u8 = 0b000;
+const FUNCT3_MISC_MEM_FENCE_I: u8 = 0b001;
 
 const FUNCT3_WIDTH_W: u8 = 0b010;
 
@@ -217,16 +218,17 @@ pub fn resolve_u32(ins: u32, xlen: Xlen) -> core::result::Result<Instruction, ()
             _ => Err(())?,
         },
         OPCODE_MISC_MEM => match funct3 {
-            FUNCT3_MISC_MEM_FENCE => Fence(i_type).into(),
+            FUNCT3_MISC_MEM_FENCE => Fence(()).into(),
+            FUNCT3_MISC_MEM_FENCE_I => FenceI(()).into(),
             _ => Err(())?,
         },
         OPCODE_SYSTEM => match funct3 {
             FUNCT3_SYSTEM_PRIV => match funct12 {
                 FUNCT12_SYSTEM_ECALL if funct3 == FUNCT3_SYSTEM_PRIV && rs1 == 0 && rd == 0 => {
-                    Ecall(i_type).into()
+                    Ecall(()).into()
                 }
                 FUNCT12_SYSTEM_EBREAK if funct3 == FUNCT3_SYSTEM_PRIV && rs1 == 0 && rd == 0 => {
-                    Ebreak(i_type).into()
+                    Ebreak(()).into()
                 }
                 _ => Err(())?,
             },

--- a/wasm-riscv-online/tests/rv32i_tests.rs
+++ b/wasm-riscv-online/tests/rv32i_tests.rs
@@ -198,7 +198,12 @@ fn test_rv32i_system_instructions() {
     // FENCE -> 0x0000000f  
     let result = disassemble("0000000f");  
     assert!(!result.starts_with("Error"));  
-    assert!(result.contains("fence"));  
+    assert!(result.contains("fence"));
+
+    // FENCE.I -> 0x0000100f
+    let result = disassemble("0000100f");
+    assert!(!result.starts_with("Error"));
+    assert!(result.contains("fence.i"));
 }  
   
 #[wasm_bindgen_test]  
@@ -253,6 +258,7 @@ fn test_rv32i_comprehensive_coverage() {
         ("003160b3", "or"),     // OR  
         ("003170b3", "and"),    // AND  
         ("0000000f", "fence"),  // FENCE  
+        ("0000100f", "fence.i"), // FENCE.I
         ("00000073", "ecall"),  // ECALL  
         ("00100073", "ebreak"), // EBREAK  
     ];  


### PR DESCRIPTION
- Add FENCE.I instruction decoding in process32.rs
- Update instruction definition in rv32i.rs
- Add test cases for FENCE.I instruction
- Optimize system instructions to use unit type instead of IType